### PR TITLE
Fix/bower name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+bower_components

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
     $ npm install slideout
 
-    $ bower install slideout
+    $ bower install https://github.com/Mango/slideout.git
 
     $ component install mango/slideout
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
-  "name": "sildeout",
-  "repository": "git@github.com:mango/sildeout.git",
+  "name": "slideout",
+  "repository": "git@github.com:mango/slideout.git",
   "description": "A touch slideout navigation menu for your mobile web apps.",
   "author": "Guille Paz <guille87paz@gmail.com>",
   "version": "0.1.1",
@@ -18,7 +18,7 @@
     "test",
     "demo"
   ],
-  "homepage": "https://github.com/mango/sildeout",
+  "homepage": "https://github.com/mango/slideout",
   "moduleType": [
     "adecouplemd",
     "globals",
@@ -30,6 +30,6 @@
     "menu",
     "touch"
   ],
-  "main": "dist/sildeout",
+  "main": "dist/slideout.js",
   "license": "MIT"
 }


### PR DESCRIPTION
@pazguille bower.json name have a little typo, `sildeout` insted of `slideout`. 
Also I update the readme because in the bower registry `slideout` is for https://github.com/okb/Slideout