### PR TITLE
Support for closing on click and edge slide in options.

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,8 @@ function Slideout(options) {
   this._duration = parseInt(options.duration, 10) || 300;
   this._tolerance = parseInt(options.tolerance, 10) || 70;
   this._padding = parseInt(options.padding, 10) || 256;
+  this._closeOnClick = options.closeOnClick || false;
+  this._grabWidth = parseInt(options.grabWidth, 10) || 0;
 
   // Init touch events
   this._initTouchEvents();
@@ -154,14 +156,25 @@ Slideout.prototype._initTouchEvents = function() {
     }
   });
 
+  if (this._closeOnClick) {
+    /**
+     * Close menu when panel is clicked while open
+     */
+    this.panel.addEventListener('click', function() {
+      if (self.isOpen) { self.close(); }
+    });
+  }
+
   /**
    * Resets values on touchstart
    */
   this.panel.addEventListener(touch.start, function(eve) {
     self._moved = false;
     self._opening = false;
-    self._startOffsetX = eve.touches[0].pageX;
-    self._preventOpen = (!self.isOpen() && self.menu.clientWidth !== 0);
+            
+    var offset = eve.touches[0].pageX;
+    self._startOffsetX = offset;
+    self._preventOpen = (!self.isOpen() && (self.menu.clientWidth !== 0 || (self._grabWidth && offset > self._grabWidth)));
   });
 
   /**


### PR DESCRIPTION
It's common in mobile apps for the menu to only slide in when dragged from the edge of the screen (not the whole screen). The new grabWidth option will allow configuring what threshold this is. If not specified, the behaviour will revert back to how it currently is. I have also added an option to allow closing the menu when it's opened (closeOnClick) by simply clicking the panel element.