### PR TITLE
Added support for event handlers

### DIFF
--- a/dist/slideout.js
+++ b/dist/slideout.js
@@ -138,7 +138,7 @@ Slideout.prototype.off = function(evt, callback) {
         for(var i=0; i < events[evt].length; i++) {
             if( callback == events[evt][i] ) {
                 events[evt].splice(i, 1);
-                this.off(evt, msg);
+                this.off(evt, callback);
                 break;
             }
         }

--- a/dist/slideout.js
+++ b/dist/slideout.js
@@ -34,6 +34,15 @@ var prefix = (function prefix() {
   if ('KhtmlOpacity' in styleDeclaration) { return '-khtml-'; }
   return '';
 }());
+var events = {
+    'open' : [],
+    'close' : []
+};
+var fireEvent = function(evt) {
+    for(var i=0; i < events[evt].length; i++) {
+        events[evt][i]();
+    }
+};
 
 /**
  * Slideout constructor
@@ -110,6 +119,28 @@ Slideout.prototype.toggle = function() {
  */
 Slideout.prototype.isOpen = function() {
   return this._opened;
+};
+
+/**
+ * Add an event listener
+ */
+Slideout.prototype.on = function(evt, callback) {
+    (events[evt] || []).push(callback);
+};
+
+/**
+ * Remove a previously added event handler
+ */
+Slideout.prototype.off = function(evt, callback) {
+    if( evt in events ) {
+        for(var i=0; i < events[evt].length; i++) {
+            if( callback == events[evt][i] ) {
+                events[evt].splice(i, 1);
+                this.off(evt, msg);
+                break;
+            }
+        }
+    }
 };
 
 /**

--- a/dist/slideout.js
+++ b/dist/slideout.js
@@ -87,6 +87,7 @@ Slideout.prototype.open = function() {
   this._opened = true;
   setTimeout(function() {
     self.panel.style.transition = self.panel.style['-webkit-transition'] = '';
+    fireEvent('open');
   }, this._duration + 50);
   return this;
 };
@@ -103,6 +104,7 @@ Slideout.prototype.close = function() {
   setTimeout(function() {
     html.className = html.className.replace(/ slideout-open/, '');
     self.panel.style.transition = self.panel.style['-webkit-transition'] = '';
+    fireEvent('close');
   }, this._duration + 50);
   return this;
 };


### PR DESCRIPTION
I don't know if this is a feature that you want nor if the solution is good enough. But here you go anyway...

I've implemented support for attaching and detaching event handlers. The events that gets triggered is `open` and `close`.

```js 
var slideout = new Slideout({
        'panel': document.getElementById('panel'),
        'menu': document.getElementById('menu'),
        'padding': 256,
        'tolerance': 70
    });

var doStuff = function() {
  console.log('doing stuff');
};

slideout.on('open', doStuff);
slideout.off('open', doStuff)

```  