### PR TITLE
Added option to show menu from right-hand side

### DIFF
--- a/index.css
+++ b/index.css
@@ -17,6 +17,11 @@ body {
   display: none;
 }
 
+.slideout-menu-right {
+  left: auto;
+  z-index: 1;
+}
+
 .slideout-panel {
   position:relative;
   z-index: 1;

--- a/index.js
+++ b/index.js
@@ -58,9 +58,16 @@ function Slideout(options) {
 
   // Sets options
   this._fx = options.fx || 'ease';
+  this._position = options.position || 'left';
   this._duration = parseInt(options.duration, 10) || 300;
   this._tolerance = parseInt(options.tolerance, 10) || 70;
   this._padding = parseInt(options.padding, 10) || 256;
+
+  // Sets right-side panel classname
+  this.menu.className += (this._position === 'left') ? '' : ' slideout-menu-right';
+
+  // Hides the menu for first show
+  this._setVisibility(false);
 
   // Init touch events
   this._initTouchEvents();
@@ -71,9 +78,11 @@ function Slideout(options) {
  */
 Slideout.prototype.open = function() {
   var self = this;
+  var translateX = (this._position === 'left') ? this._padding : this._padding * -1;
   if (html.className.search('slideout-open') === -1) { html.className += ' slideout-open'; }
   this._setTransition();
-  this._translateXTo(this._padding);
+  this._setVisibility(true);
+  this._translateXTo(translateX);
   this._opened = true;
   setTimeout(function() {
     self.panel.style.transition = self.panel.style['-webkit-transition'] = '';
@@ -93,6 +102,7 @@ Slideout.prototype.close = function() {
   setTimeout(function() {
     html.className = html.className.replace(/ slideout-open/, '');
     self.panel.style.transition = self.panel.style['-webkit-transition'] = '';
+    self._setVisibility(false);
   }, this._duration + 50);
   return this;
 };
@@ -120,10 +130,17 @@ Slideout.prototype._translateXTo = function(translateX) {
 };
 
 /**
- * Set transition properties
- */
+* Set transition properties
+*/
 Slideout.prototype._setTransition = function() {
   this.panel.style[prefix + 'transition'] = this.panel.style.transition = prefix + 'transform ' + this._duration + 'ms ' + this._fx;
+};
+
+/**
+* Set menu visibility
+*/
+Slideout.prototype._setVisibility = function(visible) {
+  this.menu.style['visibility'] = (visible) ? 'visible' : 'hidden';
 };
 
 /**

--- a/test/index.html
+++ b/test/index.html
@@ -36,11 +36,30 @@
       </section>
     </nav>
 
+    <nav id="menu-right" class="menu">
+      <a href="https://github.com/mango/slideout" target="_blank">
+        <header class="menu-header">
+          <span class="menu-header-title">Tests</span>
+        </header>
+      </a>
+
+      <section class="menu-section">
+        <h3 class="menu-section-title">Docs</h3>
+        <ul class="menu-section-list">
+          <li><a href="https://github.com/mango/slideout#installation" target="_blank">Installation</a></li>
+          <li><a href="https://github.com/mango/slideout#usage" target="_blank">Usage</a></li>
+          <li><a href="https://github.com/mango/slideout#api" target="_blank">API</a></li>
+          <li><a href="https://github.com/mango/slideout#npm-scripts" target="_blank">npm-scripts</a></li>
+        </ul>
+      </section>
+    </nav>
+
     <main id="panel" class="panel">
 
       <header class="panel-header">
         <button class="btn-hamburger js-slideout-toggle"></button>
         <h1 class="title">Slideout.js</h1>
+        <button class="btn-hamburger right js-slideout-right-toggle"></button>
       </header>
 
       <section class="box">
@@ -69,7 +88,11 @@
           slideout.toggle();
         });
 
-        document.querySelector('.menu').addEventListener('click', function(eve) {
+        document.querySelector('.js-slideout-right-toggle').addEventListener('click', function() {
+          slideoutRight.toggle();
+        });
+
+        document.querySelector('.menu, .menu-right').addEventListener('click', function(eve) {
           if (eve.target.nodeName === 'A') { slideout.close(); }
         });
 

--- a/test/test.css
+++ b/test/test.css
@@ -111,6 +111,11 @@ a {
   height: 50px;
 }
 
+.btn-hamburger.right {
+  left: auto;
+  right: 12px;
+}
+
 /**
  * Boxes
  */
@@ -163,6 +168,11 @@ a {
   .btn-hamburger {
     top: 20px;
     left: 30px;
+  }
+
+  .btn-hamburger.right {
+    left: auto;
+    right: 30px;
   }
 
   .panel-header {

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,12 @@ var slideout = new Slideout({
   'menu': doc.getElementById('menu')
 });
 
+var slideoutRight = new Slideout({
+  'panel': doc.getElementById('panel'),
+  'menu': doc.getElementById('menu-right'),
+  'position': 'right'
+});
+
 describe('Slideout', function () {
 
   it('should be defined.', function () {
@@ -85,6 +91,18 @@ describe('Slideout', function () {
       assert(slideout.panel.style.transition.search(/transform 300ms ease/) !== -1);
     });
 
+    it('should translateX the panel to a negative padding when using right position.', function () {
+      var translate3d = exports ? 'translate3d(-256px, 0, 0)' : 'translate3d(-256px, 0px, 0px)';
+      slideoutRight.open();
+      assert(slideoutRight.panel.style.transform === translate3d);
+      assert(slideoutRight.panel.style.transition.search(/transform 300ms ease/) !== -1);
+      slideoutRight.close();
+    });
+
+    it('should set the menu\'s visibility to visible.', function () {
+      assert(slideout.menu.style.visibility === 'visible');
+    });
+
     it('should set _opened to true.', function () {
       assert(slideout._opened === true);
     });
@@ -111,6 +129,10 @@ describe('Slideout', function () {
       var translate3d = exports ? 'translate3d(0px, 0, 0)' : 'translate3d(0px, 0px, 0px)';
       assert(slideout.panel.style.transform === translate3d);
       assert(slideout.panel.style.transition === '');
+    });
+
+    it('should set the menu\'s visibility to hidden.', function () {
+      assert(slideout.menu.style.visibility === 'hidden');
     });
 
     it('should set _opened to false.', function () {


### PR DESCRIPTION
Now you can tell Slideout to open from the right-hand side of the screen:

```javascript
var slideout = new Slideout({
  'panel': doc.getElementById('panel'),
  'menu': doc.getElementById('menu-right'),
  'position': 'right'
});
```

![Slideout Right side](http://g.recordit.co/3ws1stntaP.gif)

IMPORTANT NOTE: I had to add a method to set/unset visibility of the menu to hidden when it's closed, because having both a left and a right slideout, on small screens the right one would overlap the one on the left:

![Slideout Bug](http://i.imgur.com/BqkpsoJ.png)