### PR TITLE
Update index.css

### DIFF
--- a/index.css
+++ b/index.css
@@ -12,7 +12,7 @@ body {
   right: 0;
   z-index: 0;
   width: 256px;
-  overflow-y: scroll;
+  overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   display: none;
 }


### PR DESCRIPTION
using 'overflow-y: auto;' hides the scroll pane on the menu when there is no need for it but shows it when the window is too short to show it all.