### PR TITLE
Add a "change" function for callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ changing state.
 ```js
 slideout.change(function () {
   alert('open? ' + slideout.isOpen());
-}); // alerts the user after the state of the slideout has finished changed.
+}); // alerts the user after a state change.
 ```
 
 ## npm-scripts

--- a/README.md
+++ b/README.md
@@ -231,6 +231,16 @@ Returns `true` if the slideout is currently open, and `false` if it is closed.
 slideout.isOpen(); // true or false
 ```
 
+### Slideout.change(callback);
+Adds `callback` to the list of functions to be called after the slideout finishes
+changing state.
+
+```js
+slideout.change(function () {
+  alert('open? ' + slideout.isOpen());
+}); // alerts the user after the state of the slideout has finished changed.
+```
+
 ## npm-scripts
 ```
 $ npm run build

--- a/dist/slideout.js
+++ b/dist/slideout.js
@@ -65,7 +65,27 @@ function Slideout(options) {
 
   // Init touch events
   this._initTouchEvents();
+
+  // Init the change callbacks
+  this._callbacks = [];
 }
+
+/**
+ * Runs the callbacks associated with the slideout
+ */
+Slideout.prototype._runCallbacks = function () {
+  for(var i = 0; i < this._callbacks.length; ++i) {
+    this._callbacks[i]();
+  }
+};
+
+/**
+ * Stores callback functions that are called after the slideout
+ * finishes changing state
+ */
+Slideout.prototype.change = function (callback) {
+  this._callbacks[this._callbacks.length] = callback;
+};
 
 /**
  * Opens the slideout menu.
@@ -78,6 +98,7 @@ Slideout.prototype.open = function() {
   this._opened = true;
   setTimeout(function() {
     self.panel.style.transition = self.panel.style['-webkit-transition'] = '';
+    self._runCallbacks();
   }, this._duration + 50);
   return this;
 };
@@ -94,6 +115,7 @@ Slideout.prototype.close = function() {
   setTimeout(function() {
     html.className = html.className.replace(/ slideout-open/, '');
     self.panel.style.transition = self.panel.style['-webkit-transition'] = '';
+    self._runCallbacks();
   }, this._duration + 50);
   return this;
 };


### PR DESCRIPTION
While I was working on a project I was trying to get a navigation bar to stay in a fixed place after the slideout was closed, but this functionality was broken after opening the slideout. It was convenient to create a change function that would run through its callbacks *only* after the transition finished.

I figured that others might find this useful so I figured I'd submit it. I wasn't sure how what the standards here for minified code are here so I haven't submitted a minified version (I could add a commit later with the min version if I know what I should use for this project).