### PR TITLE
New option: 'heightFix'

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Create a new instance of `Slideout`.
 - `[options.tolerance]` (Number) - Default: `70`.
 - `[options.touch]` (Boolean) - Set this option to false to disable Slideout touch events. Default: `true`.
 - `[options.side]` (String) - The side to open the slideout (`left` or `right`). Default: `left`.
+- `[options.heightFix]` (Boolean) - Sets a 'min-width' property on #panel to ensure it is as high as the window on resize. Default: `false`.
 
 ```js
 var slideout = new Slideout({

--- a/dist/slideout.js
+++ b/dist/slideout.js
@@ -13,6 +13,7 @@ var Emitter = require('emitter');
 var scrollTimeout;
 var scrolling = false;
 var doc = window.document;
+var win = window;
 var html = doc.documentElement;
 var msPointerSupported = window.navigator.msPointerEnabled;
 var touch = {
@@ -61,6 +62,7 @@ function Slideout(options) {
   this._opened = false;
   this._preventOpen = false;
   this._touch = options.touch === undefined ? true : options.touch && true;
+  this._heightFix = options.heightFix === undefined ? false : options.heightFix && true;
 
   // Sets panel
   this.panel = options.panel;
@@ -79,6 +81,11 @@ function Slideout(options) {
   this._orientation = options.side === 'right' ? -1 : 1;
   this._translateTo *= this._orientation;
 
+  // Init 'panel' height fix
+  if (this._heightFix) {
+    this._initHeightFix();
+  }
+  
   // Init touch events
   if (this._touch) {
     this._initTouchEvents();
@@ -153,6 +160,23 @@ Slideout.prototype._translateXTo = function(translateX) {
 Slideout.prototype._setTransition = function() {
   this.panel.style[prefix + 'transition'] = this.panel.style.transition = prefix + 'transform ' + this._duration + 'ms ' + this._fx;
 };
+
+/**
+ * Set 'panel' to min height of the window on 'resize' and 'load' to prevent ugly slideout if window is larger than 'panel'.
+ */
+Slideout.prototype._initHeightFix = function() {
+  var self = this;
+  
+  function checkHeight() {
+    var windowHeight = window.innerHeight;
+    if (self.panel.offsetHeight != windowHeight) {
+      self.panel.style['min-height'] = windowHeight + 'px';
+    }
+  }
+  
+  checkHeight();
+  win.addEventListener('resize', checkHeight);
+}
 
 /**
  * Initializes touch event


### PR DESCRIPTION
Added an option called 'heightFix', that is a boolean. If set to true, it sets a 'min-height' property on `#panel` to ensure it is at least the height of the window.

I ran into this problem, when testing my site, where one page has only a tiny bit of content in it. If I set `body { height: 100% }`, on larger contents, it scrolls the page up if slideout is open.

I've tried multiple versions with this option, like adding the `height: 100%` property on the `body` element, not comparing with `!=`, rather with `<=`. They work, IF the user doesn't make the window smaller, or doesn't change the content. `min-height` is non-destructive (opposed to `body { height: 100% }`) and works great also while changing content and making the window smaller.

It fires as the slideout is set up, as well as on every resize.

You can see it in action here: http://groupr.fortleet.com/ . Works below 720px width.