### PR TITLE
avoid the initial jolt when starting to drag the panel

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,14 +217,18 @@ Slideout.prototype._initTouchEvents = function() {
    */
   this.panel.addEventListener(touch.move, function(eve) {
 
+    var threshold = 20;  //only start to move panel, when user drags for more than threshold pixels
+
     if (scrolling || self._preventOpen || typeof eve.touches === 'undefined') { return; }
 
     var dif_x = eve.touches[0].clientX - self._startOffsetX;
     var translateX = self._currentOffsetX = dif_x;
 
-    if (Math.abs(translateX) > self._padding) { return; }
+    if (Math.abs(translateX) > (self._padding + threshold)) { return; }
 
-    if (Math.abs(dif_x) > 20) {
+    if (Math.abs(dif_x) > threshold) {
+      var translateX_sign = translateX < 0 ? -1 : 1
+
       self._opening = true;
 
       var oriented_dif_x = dif_x * self._orientation;
@@ -233,6 +237,8 @@ Slideout.prototype._initTouchEvents = function() {
         translateX = dif_x + self._padding * self._orientation;
         self._opening = false;
       }
+
+      translateX = translateX - (threshold * translateX_sign);
 
       if (!self._moved && html.className.search('slideout-open') === -1) {
         html.className += ' slideout-open';

--- a/index.js
+++ b/index.js
@@ -217,18 +217,15 @@ Slideout.prototype._initTouchEvents = function() {
    */
   this.panel.addEventListener(touch.move, function(eve) {
 
-    var threshold = 20;  //only start to move panel, when user drags for more than threshold pixels
-
     if (scrolling || self._preventOpen || typeof eve.touches === 'undefined') { return; }
 
+    var threshold = 20;  //only start to move panel, when user drags for more than threshold pixels
     var dif_x = eve.touches[0].clientX - self._startOffsetX;
     var translateX = self._currentOffsetX = dif_x;
 
     if (Math.abs(translateX) > (self._padding + threshold)) { return; }
 
     if (Math.abs(dif_x) > threshold) {
-      var translateX_sign = translateX < 0 ? -1 : 1
-
       self._opening = true;
 
       var oriented_dif_x = dif_x * self._orientation;
@@ -238,6 +235,7 @@ Slideout.prototype._initTouchEvents = function() {
         self._opening = false;
       }
 
+      var translateX_sign = translateX < 0 ? -1 : 1
       translateX = translateX - (threshold * translateX_sign);
 
       if (!self._moved && html.className.search('slideout-open') === -1) {


### PR DESCRIPTION
this was due to the 20px threshold when deciding whether the user intended to drag the panel