### PR TITLE
Space in 'slideout-open' regex should be optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ Slideout.prototype.close = function() {
   this._translateXTo(0);
   this._opened = false;
   setTimeout(function() {
-    html.className = html.className.replace(/ slideout-open/, '');
+    html.className = html.className.replace(/ ?slideout-open/, '');
     self.panel.style.transition = self.panel.style['-webkit-transition'] = self.panel.style[prefix + 'transform'] = self.panel.style.transform = '';
     self.emit('close');
   }, this._duration + 50);


### PR DESCRIPTION
In webkit (or specifically the latest version of Safari) if the HTML class tag has exactly one other class that gets remove before slideout.close() is called then the tag value is cleaned up to remove whitespace. 

E.G. <html class="other slideout-open"> becomes <html class="slideout-open"> rather than <html class=" slideout-open">
