### PR TITLE
Add support to ignore elements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - 0.10
+  - 6.9.1
 # Send coverage data to Coveralls
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ body {
   right: 0;
   z-index: 0;
   width: 256px;
-  overflow-y: auto;
+  overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
   display: none;
 }
 
 .slideout-panel {
-  position:relative;
+  position: relative;
   z-index: 1;
   will-change: transform;
 }
@@ -136,13 +136,13 @@ Then you just include Slideout.js and create a new instance with some options:
         right: 0;
         z-index: 0;
         width: 256px;
-        overflow-y: auto;
+        overflow-y: scroll;
         -webkit-overflow-scrolling: touch;
         display: none;
       }
 
       .slideout-panel {
-        position:relative;
+        position: relative;
         z-index: 1;
         will-change: transform;
       }
@@ -429,6 +429,30 @@ slideout.on('beforeclose', function() {
 ```
 
 Demo: http://codepen.io/anon/pen/NqJGBp
+
+
+### How to disable dragging on some elements.
+You can use the attribute `data-slideout-ignore` to disable dragging on some elements:
+
+```html
+<nav id="menu">
+  <header>
+    <h2>Menu</h2>
+  </header>
+</nav>
+
+<main id="panel">
+  <header>
+    <h2>Panel</h2>
+  </header>
+  <div id="google-maps-container" data-slideout-ignore>
+    <h2>Map</h2>
+    <iframe>...</iframe>
+  </div>
+</main>
+```
+
+Demo: [TODO]
 
 ## With :heart: by
 - Guille Paz (Front-end developer | Web standards lover)

--- a/index.css
+++ b/index.css
@@ -11,13 +11,13 @@ body {
   right: 0;
   z-index: 0;
   width: 256px;
-  overflow-y: auto;
+  overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
   display: none;
 }
 
 .slideout-panel {
-  position:relative;
+  position: relative;
   z-index: 1;
   will-change: transform;
 }

--- a/index.js
+++ b/index.js
@@ -45,6 +45,15 @@ function extend(destination, from) {
 function inherits(child, uber) {
   child.prototype = extend(child.prototype || {}, uber.prototype);
 }
+function hasIgnoredElements(el) {
+  while (el.parentNode) {
+    if (el.getAttribute('data-slideout-ignore') !== null) {
+      return el;
+    }
+    el = el.parentNode;
+  }
+  return null;
+}
 
 /**
  * Slideout constructor
@@ -60,22 +69,26 @@ function Slideout(options) {
   this._opened = false;
   this._preventOpen = false;
   this._touch = options.touch === undefined ? true : options.touch && true;
+  this._side = options.side || 'left';
 
   // Sets panel
   this.panel = options.panel;
   this.menu = options.menu;
 
   // Sets  classnames
-  if(this.panel.className.search('slideout-panel') === -1) { this.panel.className += ' slideout-panel'; }
-  if(this.menu.className.search('slideout-menu') === -1) { this.menu.className += ' slideout-menu'; }
-
+  if (this.panel.className.search('slideout-panel') === -1) {
+    this.panel.className += (' slideout-panel slideout-panel-' + this._side);
+  }
+  if (this.menu.className.search('slideout-menu') === -1) {
+    this.menu.className += (' slideout-menu slideout-menu-' + this._side);
+  }
 
   // Sets options
   this._fx = options.fx || 'ease';
   this._duration = parseInt(options.duration, 10) || 300;
   this._tolerance = parseInt(options.tolerance, 10) || 70;
   this._padding = this._translateTo = parseInt(options.padding, 10) || 256;
-  this._orientation = options.side === 'right' ? -1 : 1;
+  this._orientation = this._side === 'right' ? -1 : 1;
   this._translateTo *= this._orientation;
 
   // Init touch events
@@ -95,7 +108,9 @@ inherits(Slideout, Emitter);
 Slideout.prototype.open = function() {
   var self = this;
   this.emit('beforeopen');
-  if (html.className.search('slideout-open') === -1) { html.className += ' slideout-open'; }
+  if (html.className.search('slideout-open') === -1) {
+    html.className += ' slideout-open';
+  }
   this._setTransition();
   this._translateXTo(this._translateTo);
   this._opened = true;
@@ -119,7 +134,7 @@ Slideout.prototype.close = function() {
   this._translateXTo(0);
   this._opened = false;
   setTimeout(function() {
-    html.className = html.className.replace(/ slideout-open/, '');
+    html.className = html.className.replace(/(\s)?slideout-open/, '');
     self.panel.style.transition = self.panel.style['-webkit-transition'] = self.panel.style[prefix + 'transform'] = self.panel.style.transform = '';
     self.emit('close');
   }, this._duration + 50);
@@ -230,8 +245,12 @@ Slideout.prototype._initTouchEvents = function() {
    * Translates panel on touchmove
    */
   this._onTouchMoveFn = function(eve) {
-
-    if (scrolling || self._preventOpen || typeof eve.touches === 'undefined') {
+    if (
+      scrolling ||
+      self._preventOpen ||
+      typeof eve.touches === 'undefined' ||
+      hasIgnoredElements(eve.target)
+    ) {
       return;
     }
 

--- a/index.js
+++ b/index.js
@@ -76,11 +76,17 @@ function Slideout(options) {
   this.menu = options.menu;
 
   // Sets  classnames
-  if (this.panel.className.search('slideout-panel') === -1) {
-    this.panel.className += (' slideout-panel slideout-panel-' + this._side);
+  if (!this.panel.classList.contains('slideout-panel')) {
+    this.panel.classList.add('slideout-panel');
   }
-  if (this.menu.className.search('slideout-menu') === -1) {
-    this.menu.className += (' slideout-menu slideout-menu-' + this._side);
+  if (!this.panel.classList.contains('slideout-panel-' + this._side)) {
+    this.panel.classList.add('slideout-panel-' + this._side);
+  }
+  if (!this.menu.classList.contains('slideout-menu')) {
+    this.menu.classList.add('slideout-menu');
+  }
+  if (!this.menu.classList.contains('slideout-menu-' + this._side)) {
+    this.menu.classList.add('slideout-menu-' + this._side);
   }
 
   // Sets options
@@ -108,8 +114,8 @@ inherits(Slideout, Emitter);
 Slideout.prototype.open = function() {
   var self = this;
   this.emit('beforeopen');
-  if (html.className.search('slideout-open') === -1) {
-    html.className += ' slideout-open';
+  if (!html.classList.contains('slideout-open')) {
+    html.classList.add('slideout-open');
   }
   this._setTransition();
   this._translateXTo(this._translateTo);
@@ -134,7 +140,7 @@ Slideout.prototype.close = function() {
   this._translateXTo(0);
   this._opened = false;
   setTimeout(function() {
-    html.className = html.className.replace(/(\s)?slideout-open/, '');
+    html.classList.remove('slideout-open');
     self.panel.style.transition = self.panel.style['-webkit-transition'] = self.panel.style[prefix + 'transform'] = self.panel.style.transform = '';
     self.emit('close');
   }, this._duration + 50);
@@ -280,8 +286,8 @@ Slideout.prototype._initTouchEvents = function() {
         self._opening = false;
       }
 
-      if (!self._moved && html.className.search('slideout-open') === -1) {
-        html.className += ' slideout-open';
+      if (!(self._moved && html.classList.contains('slideout-open'))) {
+        html.classList.add('slideout-open');
       }
 
       self.panel.style[prefix + 'transform'] = self.panel.style.transform = 'translateX(' + translateX + 'px)';

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
     "emitter": "git+https://github.com/Mango/emitter.git#0.0.7"
   },
   "devDependencies": {
-    "better-assert": "1.0.1",
-    "browserify": "7.0.3",
-    "coveralls": "2.11.4",
+    "better-assert": "1.0.2",
+    "browserify": "13.1.1",
+    "coveralls": "2.11.15",
     "istanbul": "0.4.5",
     "jsdom": "9.8.3",
-    "jshint": "2.6.3",
+    "jshint": "2.9.4",
     "mocha": "3.1.2",
-    "uglify-js": "2.6.1"
+    "uglify-js": "2.7.4"
   },
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "better-assert": "1.0.1",
     "browserify": "7.0.3",
     "coveralls": "2.11.4",
-    "istanbul": "0.4.1",
-    "jsdom": "3.1.1",
+    "istanbul": "0.4.5",
+    "jsdom": "9.8.3",
     "jshint": "2.6.3",
-    "mocha": "2.1.0",
+    "mocha": "3.1.2",
     "uglify-js": "2.6.1"
   },
   "main": "index.js",

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,9 @@
 if (exports) {
   var fs = require('fs');
-  var jsdom = require('jsdom');
+  var jsdom = require('jsdom').jsdom;
   var html = fs.readFileSync('./test/index.html', 'utf-8');
-  window = jsdom.jsdom(html).parentWindow;
+  var document = jsdom(html);
+  window = document.defaultView;
   var Slideout = require('../');
   var assert = require('better-assert');
 }

--- a/test/test.js
+++ b/test/test.js
@@ -84,7 +84,8 @@ describe('Slideout', function () {
       '_duration',
       '_tolerance',
       '_padding',
-      '_touch'
+      '_touch',
+      '_side'
     ];
     var i = 0;
     var len = properties.length;
@@ -100,7 +101,9 @@ describe('Slideout', function () {
 
   it('should add classnames to panel and menu DOM elements.', function () {
     assert(slideout.panel.className.search('slideout-panel') !== -1);
+    assert(slideout.panel.className.search('slideout-panel-left') !== -1);
     assert(slideout.menu.className.search('slideout-menu') !== -1);
+    assert(slideout.menu.className.search('slideout-menu-left') !== -1);
   });
 
   describe('.open()', function () {


### PR DESCRIPTION
## Features:
- Add an attribute called `data-slideout-ignore` to disable dragging on some elements (maybe for a photo slider, carousel google map, iframes, etc).
- Add classnames dynamically: `.slideout-menu-left` and `.slideout-panel-left` or `.slideout-menu-right` and `.slideout-panel-right`.
- Use `classList` instead of regexp.
- Use `overflow-y: scroll;` on `.slideout-menu`.
 
## Resolved issues:
- https://github.com/Mango/slideout/issues/78
- https://github.com/Mango/slideout/issues/196
- https://github.com/Mango/slideout/issues/203
- https://github.com/Mango/slideout/issues/200
- https://github.com/Mango/slideout/issues/144


## Resolved PRs:
- https://github.com/Mango/slideout/pull/157
- https://github.com/Mango/slideout/pull/174
- https://github.com/Mango/slideout/pull/95
- https://github.com/Mango/slideout/pull/102
- https://github.com/Mango/slideout/pull/161