### PR TITLE
Added return for touchend method.

### DIFF
--- a/dist/slideout.js
+++ b/dist/slideout.js
@@ -244,6 +244,7 @@ Slideout.prototype._initTouchEvents = function() {
       (self._opening && Math.abs(self._currentOffsetX) > self._tolerance) ? self.open() : self.close();
     }
     self._moved = false;
+    return true;
   };
 
   this.panel.addEventListener(touch.end, this._onTouchEndFn);


### PR DESCRIPTION
if none gets returned, browser throws a warning message:

`Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.`