### PR TITLE
Fix slideout get stuck when closing the app while sliding

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,6 +233,7 @@ Slideout.prototype._initTouchEvents = function() {
   this._onTouchCancelFn = function() {
     self._moved = false;
     self._opening = false;
+    self._preventOpen = false;
   };
 
   this.panel.addEventListener('touchcancel', this._onTouchCancelFn);
@@ -244,7 +245,13 @@ Slideout.prototype._initTouchEvents = function() {
     if (self._moved) {
       self.emit('translateend');
       (self._opening && Math.abs(self._currentOffsetX) > self._tolerance) ? self.open() : self.close();
+    } else if (self._currentOffsetX !== 0){
+      // Reset the slide when it's stuck and lost track of _currentOffsetX
+      self._opened = true;
+      self._startOffsetX = 0;
+      self.close();
     }
+    self._preventOpen = false;
     self._moved = false;
   };
 

--- a/index.js
+++ b/index.js
@@ -233,7 +233,6 @@ Slideout.prototype._initTouchEvents = function() {
   this._onTouchCancelFn = function() {
     self._moved = false;
     self._opening = false;
-    self._preventOpen = false;
   };
 
   this.panel.addEventListener('touchcancel', this._onTouchCancelFn);
@@ -247,7 +246,6 @@ Slideout.prototype._initTouchEvents = function() {
       (self._opening && Math.abs(self._currentOffsetX) > self._tolerance) ? self.open() : self.close();
     }
     self._moved = false;
-    self._preventOpen = false;
   };
 
   this.panel.addEventListener(touch.end, this._onTouchEndFn);
@@ -273,7 +271,7 @@ Slideout.prototype._initTouchEvents = function() {
       return;
     }
 
-    if (Math.abs(dif_x) > 20 && Math.abs(dif_y) * this._verticalRatio <= Math.abs(dif_x)) {
+    if (Math.abs(dif_x) > 20 && Math.abs(dif_y) * self._verticalRatio <= Math.abs(dif_x)) {
 
       self._opening = true;
 

--- a/index.js
+++ b/index.js
@@ -233,6 +233,7 @@ Slideout.prototype._initTouchEvents = function() {
   this._onTouchCancelFn = function() {
     self._moved = false;
     self._opening = false;
+    self._preventOpen = false;
   };
 
   this.panel.addEventListener('touchcancel', this._onTouchCancelFn);
@@ -246,6 +247,7 @@ Slideout.prototype._initTouchEvents = function() {
       (self._opening && Math.abs(self._currentOffsetX) > self._tolerance) ? self.open() : self.close();
     }
     self._moved = false;
+    self._preventOpen = false;
   };
 
   this.panel.addEventListener(touch.end, this._onTouchEndFn);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "repository": "git@github.com:mango/slideout.git",
   "description": "A touch slideout navigation menu for your mobile web apps.",
   "author": "Guille Paz <guille87paz@gmail.com>",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "build": "node browserify.js",
     "test": "npm run build && istanbul cover _mocha",


### PR DESCRIPTION
###Description

When closing the app while sliding out the panel, the `_currentOffsetX` gets stuck in the previous setting but `_moved` gets set to `false` so it's an able to move the panel.
