### PR TITLE
Support for 0 padding, tolerance and duration

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,9 +77,16 @@ function Slideout(options) {
   this._touch = options.touch === undefined ? true : options.touch && true;
   this._side = options.side || 'left';
   this._easing = options.fx || options.easing || 'ease';
-  this._duration = parseInt(options.duration, 10) || 300;
-  this._tolerance = parseInt(options.tolerance, 10) || 70;
-  this._padding = this._translateTo = parseInt(options.padding, 10) || 256;
+
+  var duration = parseInt(options.duration, 10);
+  this._duration = isNaN(duration) ? 300 : duration;
+
+  var tolerance = parseInt(options.tolerance, 10);
+  this._tolerance = isNaN(tolerance) ? 70 : tolerance;
+
+  var padding = parseInt(options.padding, 10);
+  this._padding = this._translateTo = isNaN(padding) ? 256 : padding;
+
   this._orientation = this._side === 'right' ? -1 : 1;
   this._translateTo *= this._orientation;
 


### PR DESCRIPTION
Not sure if this is by design or a bug in the library. If this is a bug please consider this PR.

Setting 0 values on initialization for padding, tolerance, or duration is not possible
with the current implementation since 0 values will become their default values. 

For example, padding set to 0 will become 256. 
If using the library so it would behave as an overlay menu, having a possibility to set 0 padding is important.

This PR will add the possibility to set 0 values for padding, tolerance, and duration.

For more info, there's an issue for this: https://github.com/Mango/slideout/issues/266