### PR TITLE
fixes direction swipe

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,6 +219,7 @@ Slideout.prototype._initTouchEvents = function() {
     self._moved = false;
     self._opening = false;
     self._startOffsetX = eve.touches[0].pageX;
+    self._startOffsetY = eve.touches[0].pageY;
     self._preventOpen = (!self._touch || (!self.isOpen() && self.menu.clientWidth !== 0));
   };
 
@@ -261,7 +262,13 @@ Slideout.prototype._initTouchEvents = function() {
     }
 
     var dif_x = eve.touches[0].clientX - self._startOffsetX;
+    var dif_y = eve.touches[0].clientY - self._startOffsetY;
     var translateX = self._currentOffsetX = dif_x;
+    var diff = 25;
+      
+    if((dif_y < (diff * -1) || dif_y > diff) && self._moved === false) {
+      return;
+    }
 
     if (Math.abs(translateX) > self._padding) {
       return;


### PR DESCRIPTION
Currently the menu opens if one swipes from left far upwards. This should not happen since touch from down to up or the other way around is scrolling other content.

The menu should only be opened if one moves it from left to right or closing from right to left.

This pr implements this fix with an allowed range of 25px up/down. (May be changed to be configurable but 25px should be a fine default value.)