### PR TITLE
Uses passive listeners to improve scrolling performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,7 +206,9 @@ Slideout.prototype._initTouchEvents = function() {
     }
   };
 
-  doc.addEventListener(touch.move, this._preventMove);
+  doc.addEventListener(touch.move, this._preventMove , {
+    passive: true
+  });
 
   /**
    * Resets values on touchstart
@@ -222,7 +224,9 @@ Slideout.prototype._initTouchEvents = function() {
     self._preventOpen = (!self._touch || (!self.isOpen() && self.menu.clientWidth !== 0));
   };
 
-  this.panel.addEventListener(touch.start, this._resetTouchFn);
+  this.panel.addEventListener(touch.start, this._resetTouchFn, {
+    passive: true
+  });
 
   /**
    * Resets values on touchcancel
@@ -297,7 +301,9 @@ Slideout.prototype._initTouchEvents = function() {
 
   };
 
-  this.panel.addEventListener(touch.move, this._onTouchMoveFn);
+  this.panel.addEventListener(touch.move, this._onTouchMoveFn, {
+    passive: true
+  });
 
   return this;
 };


### PR DESCRIPTION
Hi,

First of all - thank you for the nice library!

It seems like there is a small space for improvement. I've been running a website audit using google devtools/Lighthouse and I've got this kind of recommendation:
<img width="1154" alt="DeepinScreenshot_select-area_20190911213052" src="https://user-images.githubusercontent.com/979082/64687121-ff717f80-d4dd-11e9-800e-cae5d992437c.png">

This is it (Learn more link from the screenshot above): https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners?utm_source=lighthouse&utm_medium=devtools

> Recommendations
Add the passive flag to all of the event listeners that Lighthouse has identified. In general, add the passive flag to every wheel, mousewheel, touchstart, and touchmove event listener that does not call preventDefault().

There are a few event listeners (touchstart and touchmove) in the slideout that do not have passive: true on them. That's what I fix with this PR. I didn't commit compiled files

Audit results after the fix:
<img width="1125" alt="DeepinScreenshot_select-area_20190911214153" src="https://user-images.githubusercontent.com/979082/64687452-a1916780-d4de-11e9-8836-0d45f158f9f1.png">

