### PR TITLE
docs: Fix simple typo, precence -> presence

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ var prefix = (function prefix() {
   }
   // Nothing found so far? Webkit does not enumerate over the CSS properties of the style object.
   // However (prop in style) returns the correct value, so we'll have to test for
-  // the precence of a specific property
+  // the presence of a specific property
   if ('WebkitOpacity' in styleDeclaration) { return '-webkit-'; }
   if ('KhtmlOpacity' in styleDeclaration) { return '-khtml-'; }
   return '';


### PR DESCRIPTION
There is a small typo in index.js.

Should read `presence` rather than `precence`.

